### PR TITLE
feat: keepChannelOpen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ var tortoise = new Tortoise('amqp://localhost', options);
 
   * `connectRetries`: `Number` value greater than or equal to `-1`. Defaults to `-1`. Tortoise will attempt to connect up to this number. When set to `-1`, tortoise will attempt to connect forever. Note: This does not handle connections that have already been established and were lost see [Handling connection or channel closure](#handling-connection-or-channel-closure) for more information on that.
   * `connectRetryInterval`: `Number` value greater than or equal to `0`. Defaults to `1000`. This is the amount of time, in `ms`, that tortoise will wait before attempting to connect again.
+  * `keepChannelOpen`: `Boolean` if true, it will reuse the same channel (publish order is guaranteed for messages published in one channel). Default is false and it will create a new channel for every new publish.
 
 
 ## Publishing to a queue

--- a/lib/channelFactory.js
+++ b/lib/channelFactory.js
@@ -6,9 +6,20 @@ function channelFactory(amqpHost, options, tortoise) {
 
   var connFactory = connectionFactory.create(amqpHost, options, tortoise);
 
+  var channel;
+
   this.get = function() {
     return connFactory.get().then(function(conn) {
-      return conn.createChannel();
+      if (channel && options.keepChannelOpen) {
+        return channel;
+      }
+      channel = conn.createChannel();
+      if (options.keepChannelOpen) {
+        channel.once('closing', function () {
+          channel = null;
+        });
+      }
+      return channel;
     });
   }
 

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -1,8 +1,7 @@
 var Promise = require('bluebird')
   , msgUtils = require('./utils/msgUtils');
 
-function exchange(channelFactory, tortoise) {
-
+function exchange(channelFactory, tortoise, globalOptions) {
   var _exchange = ''
     , _type = ''
     , _opts = {};
@@ -29,14 +28,18 @@ function exchange(channelFactory, tortoise) {
     return setup().then(function(ch) {
       return msgUtils.validateAndParsePublish(msg).then(function(parsedMessage) {
         ch.publish(_exchange, routingKey, new Buffer(parsedMessage), opts);
-        return ch.close();
+        if (!globalOptions.keepChannelOpen) {
+          return ch.close();
+        }
       });
     });
   }
 
   this.setup = function() {
     return setup().then(function(ch) {
-      return ch.close();
+      if (!globalOptions.keepChannelOpen) {
+        return ch.close();
+      }
     });
   }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -5,7 +5,7 @@ var _ = require('lodash')
   , events = require('./events')
   , msgUtils = require('./utils/msgUtils');
 
-function queue(channelFactory, tortoise) {
+function queue(channelFactory, tortoise, tortoiseOptions) {
 
   var _queue = ''
     , _opts = {}
@@ -21,7 +21,7 @@ function queue(channelFactory, tortoise) {
   var setup = function() {
     return new Promise(function(resolve, reject) {
       return channelFactory.get().then(function(ch) {
-        return new Promise(function(f, r) { 
+        return new Promise(function(f, r) {
           if(_prefetch) {
             ch.prefetch(_prefetch).then(f, r);
           } else {
@@ -91,7 +91,7 @@ function queue(channelFactory, tortoise) {
 
   var subscribe = function(handler) {
     var fHandler = failHandler.create(_failOpts);
-    
+
     return setup().then(function(ch) {
       return new Promise(function(resolve, reject) {
         ch.consume(_queue, function(msg) {
@@ -135,12 +135,14 @@ function queue(channelFactory, tortoise) {
 
   this.publish = function(msg, opts) {
     opts = opts || {};
-    
+
     return msgUtils.validateAndParsePublish(msg).then(function(parsedMessage) {
       return channelFactory.get().then(function(ch) {
         return ch.assertQueue(_queue, _opts).then(function() {
           ch.sendToQueue(_queue, new Buffer(parsedMessage), opts);
-          return ch.close();
+          if (!tortoiseOptions.keepChannelOpen) {
+            return ch.close();
+          }
         });
       });
     });
@@ -151,7 +153,7 @@ function queue(channelFactory, tortoise) {
     if(typeof queue === 'object') {
       queueOpts = queue;
     }
-    
+
     if(typeof bindingOpts === 'string') {
       queue = bindingOpts;
       bindingOpts = { };
@@ -171,7 +173,9 @@ function queue(channelFactory, tortoise) {
 
   this.setup = function() {
     return setup().then(function(ch) {
-      return ch.close();
+      if (!tortoiseOptions.keepChannelOpen) {
+        return ch.close();
+      }
     });
   }
 

--- a/lib/tortoise.js
+++ b/lib/tortoise.js
@@ -10,11 +10,11 @@ function Tortoise(amqpHost, options) {
   var chFactory = channelFactory.create(amqpHost, options, this);
   
   this.exchange = function(ex, type, opts) {
-    return exchange.create(chFactory, this).configure(ex, type, opts);
+    return exchange.create(chFactory, this, options).configure(ex, type, opts);
   }
 
   this.queue = function(q, opts) {
-    return queue.create(chFactory, this).configure(q, opts);
+    return queue.create(chFactory, this, options).configure(q, opts);
   }
 
   this.destroy = function() {

--- a/test/channelFactory.js
+++ b/test/channelFactory.js
@@ -60,7 +60,7 @@ suite('channelFactory', function() {
     stubs.conn.createChannel.onCall(0).returns(p({ id: chId++ }));
     stubs.conn.createChannel.onCall(1).returns(p({ id: chId++ }));
 
-    var chFactory = channelFactory.create('');
+    var chFactory = channelFactory.create('', null, {});
     chFactory.get().then(function(ch1) {
       assert(_.isObject(ch1));
       chFactory.get().then(function(ch2) {

--- a/test/channelFactory.js
+++ b/test/channelFactory.js
@@ -60,7 +60,7 @@ suite('channelFactory', function() {
     stubs.conn.createChannel.onCall(0).returns(p({ id: chId++ }));
     stubs.conn.createChannel.onCall(1).returns(p({ id: chId++ }));
 
-    var chFactory = channelFactory.create('', null, {});
+    var chFactory = channelFactory.create('', {});
     chFactory.get().then(function(ch1) {
       assert(_.isObject(ch1));
       chFactory.get().then(function(ch2) {

--- a/test/exchange.js
+++ b/test/exchange.js
@@ -36,12 +36,12 @@ suite('exchange', function() {
   test('publish publishes message to provided exchange', function(done) {
     var stubs = build();
 
-    var ex = exchange.create(stubs.chFactory)
+    var ex = exchange.create(stubs.chFactory, null, {})
       .configure('myExchange', 'direct', {})
       .publish('rk', {Hello:'World'})
       .then(function() {
         assert(stubs.ch.publish.calledWith('myExchange', 'rk'))
-        
+
         var msg = JSON.parse(stubs.ch.publish.args[0][2].toString());
         assert.equal(msg.Hello, 'World');
 
@@ -53,10 +53,21 @@ suite('exchange', function() {
   test('publish closes channel', function(done) {
     var stubs = build();
 
-    var ex = exchange.create(stubs.chFactory)
+    var ex = exchange.create(stubs.chFactory, null, {})
       .publish('rk', {})
       .then(function() {
         assert(stubs.ch.close.calledOnce)
+        done();
+      });
+  });
+
+  test('publish keeps channel open when keepChannelOpen is set', function(done) {
+    var stubs = build();
+
+    var ex = exchange.create(stubs.chFactory, null, { keepChannelOpen: true })
+      .publish('rk', {})
+      .then(function() {
+        assert(!stubs.ch.close.called)
         done();
       });
   });
@@ -66,7 +77,7 @@ suite('exchange', function() {
 
     var opts = { persistent: true };
 
-    var ex = exchange.create(stubs.chFactory)
+    var ex = exchange.create(stubs.chFactory, null, {})
       .publish('rk', {}, opts)
       .then(function() {
         assert.equal(stubs.ch.publish.args[0][3], opts)
@@ -79,7 +90,7 @@ suite('exchange', function() {
 
     var opts = {};
 
-    exchange.create(stubs.chFactory)
+    exchange.create(stubs.chFactory, null, {})
       .configure('myExchange', 'direct', opts)
       .publish('rk', {})
       .then(function() {
@@ -91,7 +102,7 @@ suite('exchange', function() {
   test('default options are set', function(done) {
     var stubs = build();
 
-    exchange.create(stubs.chFactory)
+    exchange.create(stubs.chFactory, null, {})
       .publish('rk', {})
       .then(function() {
         assert(stubs.ch.assertExchange.calledWithExactly('', '', {}));
@@ -102,7 +113,7 @@ suite('exchange', function() {
   test('setup configures and closes channel', function(done) {
     var stubs = build();
 
-    var ex = exchange.create(stubs.chFactory)
+    var ex = exchange.create(stubs.chFactory, null, {})
       .configure('myExchange', 'direct', {})
       .setup()
       .then(function() {

--- a/test/queue.js
+++ b/test/queue.js
@@ -51,7 +51,7 @@ suite('queue', function() {
   test('publish publishes message to provided queue', function(done) {
     var stubs = build();
 
-    var ex = queue.create(stubs.chFactory)
+    var ex = queue.create(stubs.chFactory, null, {})
       .configure('myQueue', {})
       .publish({Hello:'World'})
       .then(function() {
@@ -68,10 +68,21 @@ suite('queue', function() {
   test('publish closes channel', function(done) {
     var stubs = build();
 
-    var ex = queue.create(stubs.chFactory)
+    var ex = queue.create(stubs.chFactory, null, {})
       .publish({})
       .then(function() {
         assert(stubs.ch.close.calledOnce)
+        done();
+      });
+  });
+
+  test('publish keeps channel open when keepChannelOpen is set', function(done) {
+    var stubs = build();
+
+    var ex = queue.create(stubs.chFactory, null, { keepChannelOpen: true })
+      .publish({})
+      .then(function() {
+        assert(!stubs.ch.close.called)
         done();
       });
   });
@@ -81,7 +92,7 @@ suite('queue', function() {
 
     var opts = { persistent: true };
 
-    var ex = queue.create(stubs.chFactory)
+    var ex = queue.create(stubs.chFactory, null, {})
       .publish({}, opts)
       .then(function() {
         assert.equal(stubs.ch.sendToQueue.args[0][2], opts)
@@ -94,7 +105,7 @@ suite('queue', function() {
 
     var opts = {};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('myQueue', opts)
       .publish({})
       .then(function() {
@@ -106,7 +117,7 @@ suite('queue', function() {
   test('default options are set', function(done) {
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .publish({})
       .then(function() {
         assert(stubs.ch.assertQueue.calledWithExactly('', {}));
@@ -125,7 +136,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('myQueue')
       .dead('dead.exchange', 'dead.queue')
       .subscribe(function(msg, ack) {
@@ -152,7 +163,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('myQueue')
       .dead('dead.exchange', bindingOpts, 'dead.queue', exchangeQueueOpts)
       .subscribe(function(msg, ack) {
@@ -180,7 +191,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('myQueue')
       .dead('dead.exchange', 'dead.queue', exchangeQueueOpts)
       .subscribe(function(msg, ack) {
@@ -206,7 +217,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('myQueue')
       .dead('dead.exchange')
       .subscribe(function(msg, ack) {
@@ -224,7 +235,7 @@ suite('queue', function() {
   test('subscribe to queue calls handler on message received', function(done) {
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .json()
       .subscribe(function(msg) {
         assert.equal(msg.Hello, 'World');
@@ -238,7 +249,7 @@ suite('queue', function() {
   test('subscribe sets msg data to scope', function(done) {
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(function(msg) {
         assert.equal(this.field, 'test');
         done();
@@ -253,7 +264,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(function(msg, ack) {
         ack();
 
@@ -276,7 +287,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(function(msg, ack) {
         ack(true);
 
@@ -299,7 +310,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
     
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(function(msg, ack, nack) {
         nack();
         
@@ -323,7 +334,7 @@ suite('queue', function() {
 
     var message = {content:new Buffer(JSON.stringify({Hello:'World'}))};
     
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(function(msg, ack, nack) {
         nack(false);
         
@@ -345,7 +356,7 @@ suite('queue', function() {
   test('subscribe sets prefetch when set', function(done) {
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .prefetch(1)
       .subscribe(fn)
       .then(function() {
@@ -359,7 +370,7 @@ suite('queue', function() {
   test('subscribe ignores prefetch when not set', function(done) {
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(fn)
       .then(function() {
         assert.equal(stubs.ch.prefetch.callCount, 0);
@@ -369,7 +380,7 @@ suite('queue', function() {
 
   test('subscribe with exchange binds to exchange', function(done) {
     var stubs = build();
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('my-queue')
       .exchange('my-exchange', 'topic', 'routing.key', { durable: true })
       .exchange('my-other-exchange', 'topic', 'other.routing.key', { durable: true })
@@ -385,7 +396,7 @@ suite('queue', function() {
 
   test('subscribe without exchange does not bind to exchange', function(done) {
     var stubs = build();
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .subscribe(fn)
       .then(function() {
         assert.equal(stubs.ch.assertExchange.callCount, 0);
@@ -396,7 +407,7 @@ suite('queue', function() {
 
   test('setup configures and closes channel', function(done) {
     var stubs = build();
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('my-queue')
       .exchange('my-exchange', 'topic', 'routing.key', { durable: true })
       .setup()
@@ -426,7 +437,7 @@ suite('queue', function() {
       done();
     });
     
-    queue.create(stubs.chFactory, eventEmitter)
+    queue.create(stubs.chFactory, eventEmitter, {})
       .json()
       .subscribe(function(msg, ack, nack) {
 
@@ -460,7 +471,7 @@ suite('queue', function() {
 
     var stubs = build();
 
-    queue.create(stubs.chFactory)
+    queue.create(stubs.chFactory, null, {})
       .configure('my-queue')
       .reestablish()
       .exchange('my-exchange', 'topic', 'routing.key', { durable: true })


### PR DESCRIPTION
I have a use case where I need to be sure that messages are published in the right order. Ran into an issue where, if network latency is high, messages arrived in rabbit out of order due to use of multiple channels. So I added an option to reuse the same channel.